### PR TITLE
Solving the sizing bug and acceptance

### DIFF
--- a/sd-miner-v0.0.3.py
+++ b/sd-miner-v0.0.3.py
@@ -319,8 +319,8 @@ def execute_model(config, model_id, prompt, neg_prompt, height, width, num_itera
         config.loaded_models[model_id] = current_model
 
     kwargs = {
-        'height': min(height, config.config['general']['max_height'] - config.config['general']['max_height'] % 8),
-        'width': min(width, config.config['general']['max_width'] - config.config['general']['max_width'] % 8),
+        'height': min(height, config.config['general']['max_height']),
+        'width': min(width, config.config['general']['max_width']),
         'num_inference_steps': min(num_iterations, config.config['general']['max_iterations']),
         'guidance_scale': guidance_scale,
         'negative_prompt': neg_prompt,

--- a/sd-miner-v0.0.3.py
+++ b/sd-miner-v0.0.3.py
@@ -319,8 +319,8 @@ def execute_model(config, model_id, prompt, neg_prompt, height, width, num_itera
         config.loaded_models[model_id] = current_model
 
     kwargs = {
-        'height': min(height, config.config['general']['max_height']),
-        'width': min(width, config.config['general']['max_width']),
+        'height': min(height, config.config['general']['max_height'] - config.config['general']['max_height'] % 8),
+        'width': min(width, config.config['general']['max_width'] - config.config['general']['max_width'] % 8),
         'num_inference_steps': min(num_iterations, config.config['general']['max_iterations']),
         'guidance_scale': guidance_scale,
         'negative_prompt': neg_prompt,

--- a/sd-miner-v0.0.3.py
+++ b/sd-miner-v0.0.3.py
@@ -319,8 +319,8 @@ def execute_model(config, model_id, prompt, neg_prompt, height, width, num_itera
         config.loaded_models[model_id] = current_model
 
     kwargs = {
-        'height': min(height, config.config['general']['max_height']),
-        'width': min(width, config.config['general']['max_width']),
+        'height': min(height - height % 8, config.config['general']['max_height']),
+        'width': min(width - width % 8, config.config['general']['max_width']),
         'num_inference_steps': min(num_iterations, config.config['general']['max_iterations']),
         'guidance_scale': guidance_scale,
         'negative_prompt': neg_prompt,

--- a/sd-miner-v0.0.3.py
+++ b/sd-miner-v0.0.3.py
@@ -214,7 +214,7 @@ def fetch_and_download_config_files(config):
         print(f"Need to download {len(files_to_download)} files, total size: {total_size_gb:.2f} GB")
         confirm = input("Do you want to proceed with the download? (yes/no): ")
 
-        if confirm.lower() == 'yes':
+        if confirm.strip().lower() in ['yes', 'y']:
             for i, model in enumerate(files_to_download, 1):
                 print(f"Downloading file {i}/{len(files_to_download)}")
                 download_file(config.base_dir, model['file_url'], model['name'] + ".safetensors", model['size_mb'] * 1024 * 1024)


### PR DESCRIPTION
1) Adding invalid characters to the yes/no input when requesting a download was causing an EOF error. that should get fixed with .strip()
And widening the scope of acceptable response is common practice

2) When the length or width of the image requested were not divisible by 8, the generation was failing because of StableDiffusion inner rules.
So i rounded it down to the closest number.
There might be a problem with requesting a 0x0 file and an ecception should be added to it