### PR TITLE
Configure logging to load request/processing messages, update methods to retrieve miner ids from .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,7 @@ celerybeat.pid
 .venv
 env/
 venv/
+llm-venv/
 ENV/
 env.bak/
 venv.bak/

--- a/config.toml
+++ b/config.toml
@@ -2,6 +2,7 @@
 base_url = "http://sequencer.heurist.xyz"
 num_cuda_devices = 1
 log_filename = "sd-miner.log"
+llm_log_filename = "llm-miner.log"
 version = "sd-v1.0.0"
 llm_version = "llm-v0.0.1"
 

--- a/llm_mining_core/__init__.py
+++ b/llm_mining_core/__init__.py
@@ -3,7 +3,8 @@ from .utils import (
     get_hardware_description,
     initialize_client,
     decode_prompt_llama, decode_prompt_mistral,
-    send_miner_request
+    send_miner_request,
+    configure_logging
 )
 
 __all__ = [
@@ -11,5 +12,6 @@ __all__ = [
     'get_hardware_description',
     'initialize_client',
     'decode_prompt_llama', 'decode_prompt_mistral',
-    'send_miner_request'
+    'send_miner_request',
+    'configure_logging'
 ]

--- a/llm_mining_core/base/config.py
+++ b/llm_mining_core/base/config.py
@@ -17,10 +17,12 @@ class BaseConfig:
 
     def __init__(self, config_file):
         self.config = toml.load(config_file)
-        self.miner_ids = [id.strip() for id in os.getenv('MINER_IDS', '').split(',')]
+        self.num_cuda_devices = int(self.config['general'].get('num_cuda_devices', 1))
+        self.miner_ids = [os.getenv(f'MINER_ID_{i}') for i in range(self.num_cuda_devices)]
         self.miner_ids_cycle = itertools.cycle(self.miner_ids)  # Create an iterator that cycles through the miner IDs
 
         self.base_url = self.config['general']['base_url']
+        self.log_filename = self.config['general']['llm_log_filename']
 
         self.last_heartbeat = time.time() - 10000
         # Initialize a dictionary to track the last heartbeat for each miner_id

--- a/llm_mining_core/utils/__init__.py
+++ b/llm_mining_core/utils/__init__.py
@@ -2,10 +2,12 @@ from .cuda_utils import get_hardware_description
 from .api_utils import initialize_client
 from .decoder_utils import decode_prompt_llama, decode_prompt_mistral, decode_prompt_chatml
 from .requests_utils import send_miner_request
+from .logging_utils import configure_logging
 
 __all__ = [
     'get_hardware_description',
     'initialize_client',
     'decode_prompt_llama', 'decode_prompt_mistral', 'decode_prompt_chatml',
-    'send_miner_request'
+    'send_miner_request',
+    'configure_logging'
 ]

--- a/llm_mining_core/utils/api_utils.py
+++ b/llm_mining_core/utils/api_utils.py
@@ -1,5 +1,7 @@
 import os
+import logging
 from openai import OpenAI
+
 
 def initialize_client(config, model_id):
     """
@@ -16,7 +18,7 @@ def initialize_client(config, model_id):
     """
     api_base_url = config.MODEL_TO_API_BASE_URL.get(model_id, None)
     if api_base_url is None:
-        print(f"API base URL not found for model ID: {model_id}")
+        logging.warning(f"API base URL not found for model ID: {model_id}")
         return None
 
     return OpenAI(base_url=api_base_url, api_key="N/A")

--- a/llm_mining_core/utils/logging_utils.py
+++ b/llm_mining_core/utils/logging_utils.py
@@ -1,0 +1,18 @@
+import logging
+
+def configure_logging(config, miner_id=None):
+    # Construct the log filename using both cuda_device_id and miner_id
+    base_log_filename = config.log_filename.split('.')[0]
+    if miner_id is not None:
+        process_log_filename = f"{base_log_filename}_{miner_id}.log"
+    else:
+        process_log_filename = f"{base_log_filename}.log"
+    print(f"Configuring log level to: {logging.getLevelName(logging.INFO)}. Log file name: {process_log_filename}")  # Verifying log level
+    
+    # Setup logging with the configured filename and log level
+    logging.basicConfig(
+        filename=process_log_filename,
+        filemode='a',
+        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+        level=logging.INFO
+    )

--- a/llm_mining_core/utils/requests_utils.py
+++ b/llm_mining_core/utils/requests_utils.py
@@ -37,5 +37,5 @@ def send_miner_request(config, miner_id):
         else:
             return None, None
     except Exception as e:
-        print(f"Error parsing response: {e}")
+        logging.error(f"Error parsing response: {e}")
         return None, None


### PR DESCRIPTION
This pull request introduces logging configuration utils in `llm_mining_core` which defines a consistent log format with previous stable diffusion miner; it also update ways to read miner id from .env, with the assumption that in .env user define miner id like instruction from `README.md` instead of `MINER_IDS=xxx`

```plaintext
MINER_ID_0=0xYourFirstWalletAddressHere
MINER_ID_1=0xYourSecondWalletAddressHere
```