### PR TITLE
fix: check second chunk

### DIFF
--- a/llm-miner-v0.0.2.py
+++ b/llm-miner-v0.0.2.py
@@ -126,8 +126,12 @@ def generate(config, miner_id, job_id, prompt, temperature, max_tokens, seed, st
             initial_data = first_chunk.choices[0].delta.content
                 
         if not initial_data:
-            print("No initial data received from the stream. Exiting...")
-            return
+            second_chunk = next(stream)
+            if second_chunk.choices[0].delta is not None:
+                second_data = second_chunk.choices[0].delta.content
+                if not second_data:
+                    print("No initial data received from the stream. Exiting...")
+                    return
 
         def generate_data(stream):
             yield initial_data


### PR DESCRIPTION
when steam, the content in  first chunk of response is `None`, though the contents in the following chunks are normal. 
```
ChatCompletionChunk(id='cmpl-5b95e0b0571d430883db767ae35a48ae', choices=[Choice(delta=ChoiceDelta(content=None, function_call=None, role='assistant', tool_calls=None), finish_reason=None, index=0, logprobs=None)], created=2674287, model='openhermes-2.5-mistral-7b-gptq', object='chat.completion.chunk', system_fingerprint=None)

ChatCompletionChunk(id='cmpl-5b95e0b0571d430883db767ae35a48ae', choices=[Choice(delta=ChoiceDelta(content='Conf', function_call=None, role=None, tool_calls=None), finish_reason=None, index=0, logprobs=None)], created=2674287, model='openhermes-2.5-mistral-7b-gptq', object='chat.completion.chunk', system_fingerprint=None)

ChatCompletionChunk(id='cmpl-5b95e0b0571d430883db767ae35a48ae', choices=[Choice(delta=ChoiceDelta(content='ident', function_call=None, role=None, tool_calls=None), finish_reason=None, index=0, logprobs=None)], created=2674287, model='openhermes-2.5-mistral-7b-gptq', object='chat.completion.chunk', system_fingerprint=None)
```