### PR TITLE
Modify last signal time in main loop

### DIFF
--- a/sd-miner-v1.1.0.py
+++ b/sd-miner-v1.1.0.py
@@ -142,7 +142,7 @@ def main(cuda_device_id):
     # Load the default model before entering the loop
     load_default_model(config)
 
-    last_signal_time = 0
+    last_signal_time = time.time()
     while True:
         try:
             last_signal_time = check_and_reload_model(config, last_signal_time)


### PR DESCRIPTION
This pull request modifies `last_signal_time` in main loop to ensure model loading only happens once when script starts.