### PR TITLE
decrease the gpu mem util ratio

### DIFF
--- a/llm-miner-starter.sh
+++ b/llm-miner-starter.sh
@@ -273,8 +273,8 @@ validateVram() {
         local gpu_memory_util=$(echo "scale=2; (32000-1000)/$available_mb" | bc)
     elif [[ "$heurist_model_id" == *"yi-34b-gptq"* ]] && [ "$available_mb" -gt 38000 ]; then
         local gpu_memory_util=$(echo "scale=2; (38000-1000)/$available_mb" | bc)
-    elif [[ "$heurist_model_id" == *"pro-mistral-7b"* ]] && [ "$available_mb" -gt 18000 ]; then
-        local gpu_memory_util=$(echo "scale=2; (18000-1000)/$available_mb" | bc)
+    elif [[ "$heurist_model_id" == *"pro-mistral-7b"* ]] && [ "$available_mb" -gt 16000 ]; then
+        local gpu_memory_util=$(echo "scale=2; (16000-1000)/$available_mb" | bc)
     else
         local gpu_memory_util=$(echo "scale=2; (12000-1000)/$available_mb" | bc) # Default value or handle other cases as needed
     fi


### PR DESCRIPTION
Tested on RTX4090 (24 GB), before this change, even for sd-miner using `--exclude-sdxl` option, the `openhermes-2-pro-mistral-7b` still cannot fit in. After this, it can run sd-miner with `--exclude-sdxl` option and llm-miner with this model option.